### PR TITLE
fix: resolve bad overlap on tsci dev overlay during export

### DIFF
--- a/dev-server-frontend/src/components/dialogs/generic-export-dialog.tsx
+++ b/dev-server-frontend/src/components/dialogs/generic-export-dialog.tsx
@@ -148,7 +148,7 @@ export const GenericExportDialog = ({
   onClickExport: () => any
 }) => {
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
+    <Dialog open={open} onClose={onClose} className="relative z-[101]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
         <Dialog.Panel className="w-full max-w-lg rounded bg-white p-6 border border-[rgba(0,0,0,0.3)]">

--- a/dev-server-frontend/src/components/dialogs/gerber-export-dialog.tsx
+++ b/dev-server-frontend/src/components/dialogs/gerber-export-dialog.tsx
@@ -125,7 +125,7 @@ export const GerberExportDialog = ({
   onClickExport: () => any
 }) => {
   return (
-    <Dialog open={open} onClose={onClose} className="relative z-50">
+    <Dialog open={open} onClose={onClose} className="relative z-[101]">
       <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
       <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
         <Dialog.Panel className="w-full max-w-lg rounded bg-white p-6 border border-[rgba(0,0,0,0.3)]">


### PR DESCRIPTION
fixes: https://github.com/tscircuit/tscircuit/issues/212

Screenshots:
1. As current maximum Canvas z-index is 100
![Screenshot from 2024-07-01 12-03-47](https://github.com/tscircuit/cli/assets/44433679/6dc77c4b-94fc-4bbc-a89d-842797fa3023)

2. With z-index:101
![Screenshot from 2024-07-01 11-59-37](https://github.com/tscircuit/cli/assets/44433679/e4cbf947-1196-42ae-9410-e1395662879c)
