### PR TITLE
fix: add node_moduels in gitignore

### DIFF
--- a/lib/cmd-fns/init/index.ts
+++ b/lib/cmd-fns/init/index.ts
@@ -104,7 +104,7 @@ export const initCmd = async (ctx: AppContext, args: any) => {
   writeFileSync("package.json", JSON.stringify(packageJson, null, 2))
 
   console.log(`Adding ".tscircuit" to .gitignore`)
-  appendFileSync(".gitignore", "\n.tscircuit\n*.__tmp_entrypoint.tsx\ndist", {
+  appendFileSync(".gitignore", "\n.tscircuit\n*.__tmp_entrypoint.tsx\ndist\nnode_modules\n", {
     encoding: "utf-8",
     flag: "a+",
   })


### PR DESCRIPTION
Found this bug, while doing `tsci init` and then the generated node_modules were not ignored. Had to add it myself